### PR TITLE
Templating from file + Exit code

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,9 @@ inputs:
     required: false
     default: false
   variables:
-    required: true
+    required: false
+  data_file:
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -16,4 +16,6 @@ if os.environ.get('INPUT_STRICT') == 'true':
 
 params.extend(['-o', os.environ['INPUT_OUTPUT_FILE']])
 
-subprocess.run(['jinja2'] + params)
+params.extend([os.environ.get('INPUT_DATA_FILE','')])
+
+subprocess.run(['jinja2'] + params, check = True)


### PR DESCRIPTION
This PR does two things:

1. Allows the action to specify a `data_file`, to support setting variables from a file instead of from the action itself.
2. Correctly passes subprocess exit code, meaning if `jinja2` has non-zero exit then the action will properly fail.