### PR TITLE
Pin image base to python3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.11
 
 WORKDIR /app
 ENTRYPOINT ["/app/entrypoint.py"]


### PR DESCRIPTION
python3.12 has been recently release, seems that is causing trouble:
```
Traceback (most recent call last):
  File "/app/entrypoint.py", line 5, in <module>
    from main import Context
  File "/app/main.py", line 2, in <module>
    from j2cli.context import read_context_data
  File "/usr/local/lib/python3.12/site-packages/j2cli/__init__.py", line 10, in <module>
    from j2cli.cli import main
  File "/usr/local/lib/python3.12/site-packages/j2cli/cli.py", line 8, in <module>
    import imp, inspect
ModuleNotFoundError: No module named 'imp'
```