### PR TITLE
(perf): Convert Python base image to python:3.11-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.11-slim
 
 WORKDIR /app
 ENTRYPOINT ["/app/entrypoint.py"]
@@ -8,4 +8,5 @@ RUN pip install poetry \
  && poetry config virtualenvs.create false \
  && poetry install
 
-COPY . ./
+COPY *.py ./
+COPY test/ ./test


### PR DESCRIPTION
The current Dockerfile assumes the base Debain Python image (`python:3.11`) which produces a final image that is approximately 1.0 GB in size. 
```
docker build . -t tests:debian
docker image ls | grep "tests:debian"
tests:debian             latest        bbd315631e3e   46 seconds ago   1.09GB
```

Since GitHub Actions has to build this image at runtime, I propose we use the Slim (`python:3.11-slim`) image instead. This change produces a final Docker image that is approximately 231 MB in size. 
```
docker build . -t tests:debian-slim
docker image ls | grep "tests:debian-slim"
tests:debian-slim        latest        40f097c44a36   2 seconds ago       231MB
```

We could get further size reductions if we were to use the `python:3.11-alpine` image. However, I believe that sticking to a  a Debian-based image prevents compatibility issues when using Python libraries with C extensions. I am open to using the `alpine` Docker image if you are confident that the current dependencies play nice with the Alpine Linux platform. I was able to successfully build and test an Alpine Docker image.

```
docker build . -t tests:alpine
docker image ls | grep "tests:alpine"
tests:alpine             latest        b6d56e866048   15 minutes ago   139MB
docker run --entrypoint python tests:alpine unit-tests.py
....
----------------------------------------------------------------------
Ran 4 tests in 0.003s

OK
```