### PR TITLE
Solve poetry requirement for README.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM python:3.11
 WORKDIR /app
 ENTRYPOINT ["/app/entrypoint.py"]
 
-COPY poetry.lock pyproject.toml ./
+COPY poetry.lock pyproject.toml README.md ./
 RUN pip install poetry \
  && poetry config virtualenvs.create false \
- && poetry install
+ && poetry install --no-root
 
 COPY . ./


### PR DESCRIPTION
Since poetry 2.0 the install command requires the README.md to be present. Also the --no-root is required as we are not really installing the "current project" but only the dependencies.